### PR TITLE
Add tabs to seeker bookings

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -18,7 +18,9 @@ class BookingsController < ApplicationController
 
   def seeker_index
     @user = User.find(params[:id])
-    @bookings = Booking.where(user_id: @user, status: "Pending")
+    @pending_bookings = Booking.where(user_id: @user, status: "Pending")
+    @accepted_bookings = Booking.where(user_id: @user, status: "Accepted")
+    @declined_bookings = Booking.where(user_id: @user, status: "Declined")
   end
 
   def accept_booking

--- a/app/views/bookings/_booking_items.html.erb
+++ b/app/views/bookings/_booking_items.html.erb
@@ -1,0 +1,28 @@
+<ul class="list-group mt-2">
+  <% if bookings.empty? %>
+    <p>You have no offers here</p>
+  <% else %>
+    <% bookings.each do |booking| %>
+      <li class="list-group-item mt-1">
+        <div class="d-flex align-items-center justify-content-between">
+          <div class="d-flex align-items-center">
+            <div>
+              <%="You requested a  #{booking.product.category.title.downcase} and got offered a "%>
+              <%= link_to booking.product.title, product_path(booking.product) %>
+            </div>
+          </div>
+          <div>
+            <div class="btn-group">
+              <%= link_to(accept_booking_path(booking), class: "btn btn-success", method: :get, data: { confirm: "Are you sure you want to accept this offer?"}) do %>
+                Accept
+              <% end %>
+              <%= link_to(decline_booking_path(booking), class: "btn btn-danger", method: :get, data: { confirm: "Are you sure you want to decline this offer?"}) do %>
+                Decline
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </li>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/bookings/_booking_items.html.erb
+++ b/app/views/bookings/_booking_items.html.erb
@@ -1,6 +1,6 @@
 <ul class="list-group mt-2">
   <% if bookings.empty? %>
-    <p>You have no offers here</p>
+    <p class="m-4">You have no offers here</p>
   <% else %>
     <% bookings.each do |booking| %>
       <li class="list-group-item mt-1">

--- a/app/views/bookings/seeker_index.html.erb
+++ b/app/views/bookings/seeker_index.html.erb
@@ -30,6 +30,3 @@
     <%= link_to "Back to all seekers", seekers_path, class: "btn btn-primary mt-3" %>
   </div>
 </div>
-
-
-

--- a/app/views/bookings/seeker_index.html.erb
+++ b/app/views/bookings/seeker_index.html.erb
@@ -2,34 +2,7 @@
   <h2>Pending offers</h2>
   <div class="row m-0">
     <div class="col p-0">
-      <ul class="list-group mt-2">
-        <% if @bookings.empty? %>
-          <p>You have no pending offers</p>
-        <% else %>
-          <% @bookings.each do |booking| %>
-            <li class="list-group-item mt-1">
-              <div class="d-flex align-items-center justify-content-between">
-                <div class="d-flex align-items-center">
-                  <div>
-                    <%="You requested a  #{booking.product.category.title.downcase} and got offered a "%>
-                    <%= link_to booking.product.title, product_path(booking.product) %>
-                  </div>
-                </div>
-                <div>
-                  <div class="btn-group">
-                    <%= link_to(accept_booking_path(booking), class: "btn btn-success", method: :get, data: { confirm: "Are you sure you want to accept this offer?"}) do %>
-                      Accept
-                    <% end %>
-                    <%= link_to(decline_booking_path(booking), class: "btn btn-danger", method: :get, data: { confirm: "Are you sure you want to decline this offer?"}) do %>
-                      Decline
-                    <% end %>
-                  </div>
-                </div>
-              </div>
-            </li>
-          <% end %>
-        <% end %>
-      </ul>
+      <%= render 'booking_items', bookings: @pending_bookings %>
     </div>
   </div>
   <div class="mt-2">

--- a/app/views/bookings/seeker_index.html.erb
+++ b/app/views/bookings/seeker_index.html.erb
@@ -1,8 +1,29 @@
 <div class="container my-4">
-  <h2>Pending offers</h2>
+  <h2>Offers</h2>
   <div class="row m-0">
     <div class="col p-0">
-      <%= render 'booking_items', bookings: @pending_bookings %>
+      <ul class="nav nav-tabs" id="myTab" role="tablist">
+        <li class="nav-item" role="presentation">
+          <button class="nav-link active" id="pending-tab" data-bs-toggle="tab" data-bs-target="#pending" type="button" role="tab" aria-controls="pending" aria-selected="true">Pending</button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="accepted-tab" data-bs-toggle="tab" data-bs-target="#accepted" type="button" role="tab" aria-controls="accepted" aria-selected="false">Accepted</button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="declined-tab" data-bs-toggle="tab" data-bs-target="#declined" type="button" role="tab" aria-controls="declined" aria-selected="false">Declined</button>
+        </li>
+      </ul>
+      <div class="tab-content" id="myTabContent">
+        <div class="tab-pane fade show active" id="pending" role="tabpanel" aria-labelledby="pending-tab">
+          <%= render 'booking_items', bookings: @pending_bookings %>
+        </div>
+        <div class="tab-pane fade" id="accepted" role="tabpanel" aria-labelledby="accepted-tab">
+          <%= render 'booking_items', bookings: @accepted_bookings %>
+        </div>
+        <div class="tab-pane fade" id="declined" role="tabpanel" aria-labelledby="declined-tab">
+          <%= render 'booking_items', bookings: @declined_bookings %>
+        </div>
+      </div>
     </div>
   </div>
   <div class="mt-2">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,5 +20,6 @@
       </div>
       <%= render 'shared/footer' %>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js" integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0" crossorigin="anonymous"></script>
   </body>
 </html>


### PR DESCRIPTION
Added tabs to the seekers bookings/offer page so they click between pending, accepted and declined offers.

We can change the colours of the offer action buttons once we have declined on success and danger colours, perhaps?