### PR TITLE
Fix product show page no image catch

### DIFF
--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :meta_title, "#{ @product.title } | #{DEFAULT_META["meta_product_name"]}" %>
 <% content_for :meta_description, "#{ @product.description }" %>
-<% if @product.photo %>
+<% if @product.photo.attached? %>
   <% content_for :meta_image, cl_image_path(@product.photo.key) %>
 <% end %>
 


### PR DESCRIPTION
Product#show no longer crashes if there is no image